### PR TITLE
SS-947 Propagate exceptions from io thread up to main thread

### DIFF
--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -244,14 +244,7 @@ AsyncSickSafetyScanner::AsyncSickSafetyScanner(sick::types::ip_address_t sensor_
   , m_work(sick::make_unique<boost::asio::io_service::work>(m_io_service))
 {
   m_service_thread = boost::thread([this] {
-    try
-    {
-      m_io_service.run();
-    }
-    catch (const std::exception& e)
-    {
-      LOG_ERROR("%s", e.what());
-    }
+    m_io_service.run();
   });
 }
 
@@ -265,14 +258,7 @@ AsyncSickSafetyScanner::AsyncSickSafetyScanner(sick::types::ip_address_t sensor_
   , m_work(sick::make_unique<boost::asio::io_service::work>(m_io_service))
 {
   m_service_thread = boost::thread([this] {
-    try
-    {
-      m_io_service.run();
-    }
-    catch (const std::exception& e)
-    {
-      LOG_ERROR("%s", e.what());
-    }
+    m_io_service.run();
   });
 }
 


### PR DESCRIPTION
Don't exit silently if io thread has an exception. Allow other recoveries in ros2 like node respawn to restart the node.

Respawn works after this change:
![Screenshot from 2024-05-31 11-20-36](https://github.com/cmrobotics/sick_safetyscanners_base/assets/18737820/8d94631f-b9a9-43b4-b986-1ac729a90a52)
